### PR TITLE
Add confirmedDate and confirmedTime helper functions

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -393,6 +393,8 @@ getMillisecond	KEYWORD2
 getNanosecond	KEYWORD2
 getDateValid	KEYWORD2
 getTimeValid	KEYWORD2
+getconfirmedDate	KEYWORD2
+getConfirmedTime	KEYWORD2
 getFixType	KEYWORD2
 getGnssFixOk	KEYWORD2
 getDiffSoln	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -393,7 +393,7 @@ getMillisecond	KEYWORD2
 getNanosecond	KEYWORD2
 getDateValid	KEYWORD2
 getTimeValid	KEYWORD2
-getconfirmedDate	KEYWORD2
+getConfirmedDate	KEYWORD2
 getConfirmedTime	KEYWORD2
 getFixType	KEYWORD2
 getGnssFixOk	KEYWORD2

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -8895,6 +8895,34 @@ bool SFE_UBLOX_GNSS::getTimeValid(uint16_t maxWait)
   return ((bool)packetUBXNAVPVT->data.valid.bits.validTime);
 }
 
+//Get the confirmed date validity
+bool SFE_UBLOX_GNSS:: getConfirmedDate(uint16_t maxWait)
+{
+  if (packetUBXNAVPVT == NULL) initPacketUBXNAVPVT(); //Check that RAM has been allocated for the PVT data
+  if (packetUBXNAVPVT == NULL) //Bail if the RAM allocation failed
+    return (false);
+
+  if (packetUBXNAVPVT->moduleQueried.moduleQueried1.bits.confirmedDate == false)
+    getPVT(maxWait);
+  packetUBXNAVPVT->moduleQueried.moduleQueried1.bits.confirmedDate = false; //Since we are about to give this to user, mark this data as stale
+  packetUBXNAVPVT->moduleQueried.moduleQueried1.bits.all = false;
+  return ((bool)packetUBXNAVPVT->data.flags2.bits.confirmedDate);
+}
+
+//Get the confirmed time validity
+bool SFE_UBLOX_GNSS:: getConfirmedTime(uint16_t maxWait)
+{
+  if (packetUBXNAVPVT == NULL) initPacketUBXNAVPVT(); //Check that RAM has been allocated for the PVT data
+  if (packetUBXNAVPVT == NULL) //Bail if the RAM allocation failed
+    return (false);
+
+  if (packetUBXNAVPVT->moduleQueried.moduleQueried1.bits.confirmedTime == false)
+    getPVT(maxWait);
+  packetUBXNAVPVT->moduleQueried.moduleQueried1.bits.confirmedTime = false; //Since we are about to give this to user, mark this data as stale
+  packetUBXNAVPVT->moduleQueried.moduleQueried1.bits.all = false;
+  return ((bool)packetUBXNAVPVT->data.flags2.bits.confirmedTime);
+}
+
 //Get the current fix type
 //0=no fix, 1=dead reckoning, 2=2D, 3=3D, 4=GNSS, 5=Time fix
 uint8_t SFE_UBLOX_GNSS::getFixType(uint16_t maxWait)

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -927,6 +927,8 @@ public:
 
 	bool getDateValid(uint16_t maxWait = defaultMaxWait);
 	bool getTimeValid(uint16_t maxWait = defaultMaxWait);
+	bool getConfirmedDate(uint16_t maxWait = defaultMaxWait);
+	bool getConfirmedTime(uint16_t maxWait = defaultMaxWait);
 
 	uint8_t getFixType(uint16_t maxWait = defaultMaxWait); //Returns the type of fix: 0=no, 3=3D, 4=GNSS+Deadreckoning
 


### PR DESCRIPTION
Hiya @PaulZC,

A quick PR to add the helper functions to query the UBX-NAV-PVT confirmedDate and confirmedTime flags from the flags2 bitfield. Supports u-blox receivers running Protocol Versions 19.00 and higher. 

Please let me know if there are any changes necessary!

Cheers,
Adam