### PR TITLE
Modify state management aberridg

### DIFF
--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -507,6 +507,15 @@ struct ubxPacket
 	uint8_t checksumB;
 	sfe_ublox_packet_validity_e valid;			 //Goes from NOT_DEFINED to VALID or NOT_VALID when checksum is checked
 	sfe_ublox_packet_validity_e classAndIDmatch; // Goes from NOT_DEFINED to VALID or NOT_VALID when the Class and ID match the requestedClass and requestedID
+	bool isClassAndIdMatch(uint8_t theClass, uint8_t theId) {
+		return cls == theClass && theId == id;
+	}
+	bool isAckForClassAndId(uint8_t theClass, uint8_t theId) {
+		return isClassAndIdMatch(UBX_CLASS_ACK, UBX_ACK_ACK) && payload[0] == theClass && payload[1] == theId;
+	}
+	bool isNackForClassAndId(uint8_t theClass, uint8_t theId) {
+		return isClassAndIdMatch(UBX_CLASS_ACK, UBX_ACK_NACK) && payload[0] == theClass && payload[1] == theId;
+	}
 };
 
 // Struct to hold the results returned by getGeofenceState (returned by UBX-NAV-GEOFENCE)
@@ -639,7 +648,7 @@ public:
 
 	// After sending a message to the module, wait for the expected response (data+ACK or just data)
 
-	sfe_ublox_status_e waitForACKResponse(ubxPacket *outgoingUBX, uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = defaultMaxWait);	 //Poll the module until a config packet and an ACK is received, or just an ACK
+	sfe_ublox_status_e waitForACKResponse(ubxPacket *outgoingUBX, uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = defaultMaxWait, bool expectACKonly = false);	 //Poll the module until a config packet and an ACK is received, or just an ACK
 	sfe_ublox_status_e waitForNoACKResponse(ubxPacket *outgoingUBX, uint8_t requestedClass, uint8_t requestedID, uint16_t maxTime = defaultMaxWait); //Poll the module until a config packet is received
 
 	// Check if any callbacks need to be called
@@ -1300,7 +1309,7 @@ private:
 	//The packet buffers
 	//These are pointed at from within the ubxPacket
 	uint8_t payloadAck[2];				  // Holds the requested ACK/NACK
-	uint8_t payloadBuf[2];				  // Temporary buffer used to screen incoming packets or dump unrequested packets
+	uint8_t payloadBuf[MAX_PAYLOAD_SIZE];				  // Temporary buffer used to screen incoming packets or dump unrequested packets aberridg TODO: figure out if we can reduce memory usage by not using the whole buffer - needs some clean-up
 	size_t packetCfgPayloadSize = 0; // Size for the packetCfg payload. .begin will set this to MAX_PAYLOAD_SIZE if necessary. User can change with setPacketCfgPayloadSize
 	uint8_t *payloadCfg = NULL;
 	uint8_t *payloadAuto = NULL;

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -51,6 +51,8 @@
 
 #include <Wire.h>
 
+#include <SPI.h>
+
 #include "u-blox_config_keys.h"
 #include "u-blox_structs.h"
 
@@ -560,6 +562,8 @@ public:
 	boolean begin(TwoWire &wirePort = Wire, uint8_t deviceAddress = 0x42); //Returns true if module is detected
 	//serialPort needs to be perviously initialized to correct baud rate
 	boolean begin(Stream &serialPort); //Returns true if module is detected
+	//SPI - supply instance of SPIClass, slave select pin and SPI speed (in Hz)
+	boolean begin(SPIClass &spiPort, uint8_t ssPin, int spiSpeed);
 
 	void end(void); //Stop all automatic message processing. Free all used RAM
 
@@ -612,6 +616,7 @@ public:
 
 	boolean checkUbloxI2C(ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID);	   //Method for I2C polling of data, passing any new bytes to process()
 	boolean checkUbloxSerial(ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID); //Method for serial polling of data, passing any new bytes to process()
+	boolean checkUbloxSpi(ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID); //Method for spi polling of data, passing any new bytes to process()
 
 	// Process the incoming data
 
@@ -622,12 +627,13 @@ public:
 	void processUBX(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID); //Given a character, file it away into the uxb packet structure
 	void processUBXpacket(ubxPacket *msg); //Once a packet has been received and validated, identify this packet's class/id and update internal flags
 
-	// Send I2C/Serial commands to the module
+	// Send I2C/Serial/SPI commands to the module
 
 	void calcChecksum(ubxPacket *msg); //Sets the checksumA and checksumB of a given messages
 	sfe_ublox_status_e sendCommand(ubxPacket *outgoingUBX, uint16_t maxWait = defaultMaxWait, boolean expectACKonly = false); //Given a packet and payload, send everything including CRC bytes, return true if we got a response
 	sfe_ublox_status_e sendI2cCommand(ubxPacket *outgoingUBX, uint16_t maxWait = defaultMaxWait);
 	void sendSerialCommand(ubxPacket *outgoingUBX);
+	void sendSpiCommand(ubxPacket *outgoingUBX);
 
 	void printPacket(ubxPacket *packet, boolean alwaysPrintPayload = false); //Useful for debugging
 
@@ -1235,6 +1241,9 @@ private:
 	//Calculate how much RAM is needed to store the payload for a given automatic message
 	uint16_t getMaxPayloadSize(uint8_t Class, uint8_t ID);
 
+	//Do the actual transfer to SPI
+	void spiTransfer(uint8_t byteToTransfer);
+
 	boolean initGeofenceParams(); // Allocate RAM for currentGeofenceParams and initialize it
 	boolean initModuleSWVersion(); // Allocate RAM for moduleSWVersion and initialize it
 
@@ -1273,6 +1282,10 @@ private:
 	Stream *_nmeaOutputPort = NULL; //The user can assign an output port to print NMEA sentences if they wish
 	Stream *_debugSerial;			//The stream to send debug messages to if enabled
 
+	SPIClass *_spiPort;				//The instance of SPIClass
+	uint8_t _ssPin;					//The slave select pin
+	int _spiSpeed;					//The speed to use for SPI (Hz)
+
 	uint8_t _gpsI2Caddress = 0x42; //Default 7-bit unshifted address of the ublox 6/7/8/M8/F9 series
 	//This can be changed using the ublox configuration software
 
@@ -1291,6 +1304,9 @@ private:
 	size_t packetCfgPayloadSize = 0; // Size for the packetCfg payload. .begin will set this to MAX_PAYLOAD_SIZE if necessary. User can change with setPacketCfgPayloadSize
 	uint8_t *payloadCfg = NULL;
 	uint8_t *payloadAuto = NULL;
+
+	uint8_t spiBuffer[20]; 				// A small buffer to store any bytes being recieved back from the device while we are sending via SPI
+	uint8_t spiBufferIndex = 0;			// The index into the SPI buffer
 
 	//Init the packet structures and init them with pointers to the payloadAck, payloadCfg, payloadBuf and payloadAuto arrays
 	ubxPacket packetAck = {0, 0, 0, 0, 0, payloadAck, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -506,7 +506,6 @@ struct ubxPacket
 	uint8_t checksumA; //Given to us from module. Checked against the rolling calculated A/B checksums.
 	uint8_t checksumB;
 	sfe_ublox_packet_validity_e valid;			 //Goes from NOT_DEFINED to VALID or NOT_VALID when checksum is checked
-	sfe_ublox_packet_validity_e classAndIDmatch; // Goes from NOT_DEFINED to VALID or NOT_VALID when the Class and ID match the requestedClass and requestedID
 	bool isClassAndIdMatch(uint8_t theClass, uint8_t theId) {
 		return cls == theClass && theId == id;
 	}
@@ -1318,10 +1317,10 @@ private:
 	uint8_t spiBufferIndex = 0;			// The index into the SPI buffer
 
 	//Init the packet structures and init them with pointers to the payloadAck, payloadCfg, payloadBuf and payloadAuto arrays
-	ubxPacket packetAck = {0, 0, 0, 0, 0, payloadAck, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
-	ubxPacket packetBuf = {0, 0, 0, 0, 0, payloadBuf, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
-	ubxPacket packetCfg = {0, 0, 0, 0, 0, payloadCfg, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
-	ubxPacket packetAuto = {0, 0, 0, 0, 0, payloadAuto, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
+	ubxPacket packetAck = {0, 0, 0, 0, 0, payloadAck, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
+	ubxPacket packetBuf = {0, 0, 0, 0, 0, payloadBuf, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
+	ubxPacket packetCfg = {0, 0, 0, 0, 0, payloadCfg, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
+	ubxPacket packetAuto = {0, 0, 0, 0, 0, payloadAuto, 0, 0, SFE_UBLOX_PACKET_VALIDITY_NOT_DEFINED};
 
 	//Flag if this packet is unrequested (and so should be ignored and not copied into packetCfg or packetAck)
 	boolean ignoreThisPayload = false;

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -632,7 +632,7 @@ public:
 	void processNMEA(char incoming) __attribute__((weak)); //Given a NMEA character, do something with it. User can overwrite if desired to use something like tinyGPS or MicroNMEA libraries
 	void processRTCMframe(uint8_t incoming); //Monitor the incoming bytes for start and length bytes
 	void processRTCM(uint8_t incoming) __attribute__((weak)); //Given rtcm byte, do something with it. User can overwrite if desired to pipe bytes to radio, internet, etc.
-	void processUBX(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID); //Given a character, file it away into the uxb packet structure
+	void processUBX(uint8_t incoming, ubxPacket *incomingUBX); //Given a character, file it away into the uxb packet structure
 	void processUBXpacket(ubxPacket *msg); //Once a packet has been received and validated, identify this packet's class/id and update internal flags
 
 	// Send I2C/Serial/SPI commands to the module


### PR DESCRIPTION
Hi Paul,

A bigger pull request this time. Sorry about the size of it, but I thought it better to do a bulk update that works, rather than something piecemeal... I have revised the state management for sending/receiving packets and verifying that received messages/acks are the result of previously sent commands. 

I've removed the classAndIdMatch flag, replacing it with a member function on the ubxPacket. I've also added a couple of member functions for checking if a packet is an ack or a nack for the requested class/ID.

This is easier to troubleshoot/debug than having different parts of code setting flags and keeping track of them all the time. It also removes the need for processUBX to be aware of the class/ID it expects. I also wonder if the flags lead to race conditions/indeterminate outcomes. The resulting logic is also a lot simpler and removes quite a lot of code!

I notice an immediate improvement in performance and reliability - e.g, before I made these changes, I set HNR messages at 30Hz in one sketch. Then I opened another sketch and tried to disable the messages. None of my commands to disable messages got through! 

Making these changes, enabled the commands to be accepted, and all their acks/nacks to be properly tracked. I can also receive HNR packets at 30Hz totally reliably. 

Andrew