### PR TITLE
Update u-blox_structs.h

### DIFF
--- a/src/u-blox_structs.h
+++ b/src/u-blox_structs.h
@@ -1104,7 +1104,7 @@ typedef struct
 
 // UBX-RXM-RAWX (0x02 0x15): Multi-GNSS raw measurement data
 // Note: length is variable
-const uint8_t UBX_RXM_RAWX_MAX_BLOCKS = 64; // GUESS! TO DO: find the correct value for this
+const uint8_t UBX_RXM_RAWX_MAX_BLOCKS = 92; // Based off max number of channels in ZED-F9P
 const uint16_t UBX_RXM_RAWX_MAX_LEN = 16 + (32 * UBX_RXM_RAWX_MAX_BLOCKS);
 
 typedef struct


### PR DESCRIPTION
UBX_RXM_RAWX_MAX_BLOCKS updated to reflect max number of channels (ie, measurements) of ZED-F9P (92). #70 