### PR TITLE
Add maxWait to begin functions

### DIFF
--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -406,7 +406,7 @@ void SFE_UBLOX_GNSS::setPacketCfgPayloadSize(size_t payloadSize)
 }
 
 //Initialize the I2C port
-bool SFE_UBLOX_GNSS::begin(TwoWire &wirePort, uint8_t deviceAddress)
+bool SFE_UBLOX_GNSS::begin(TwoWire &wirePort, uint8_t deviceAddress, uint16_t maxWait)
 {
   commType = COMM_TYPE_I2C;
   _i2cPort = &wirePort; //Grab which port the user wants us to use
@@ -429,19 +429,19 @@ bool SFE_UBLOX_GNSS::begin(TwoWire &wirePort, uint8_t deviceAddress)
   createFileBuffer();
 
   // Call isConnected up to three times - tests on the NEO-M8U show the CFG RATE poll occasionally being ignored
-  bool connected = isConnected();
+  bool connected = isConnected(maxWait);
 
   if (!connected)
-    connected = isConnected();
+    connected = isConnected(maxWait);
 
   if (!connected)
-    connected = isConnected();
+    connected = isConnected(maxWait);
 
   return (connected);
 }
 
 //Initialize the Serial port
-bool SFE_UBLOX_GNSS::begin(Stream &serialPort)
+bool SFE_UBLOX_GNSS::begin(Stream &serialPort, uint16_t maxWait)
 {
   commType = COMM_TYPE_SERIAL;
   _serialPort = &serialPort; //Grab which port the user wants us to use
@@ -454,19 +454,19 @@ bool SFE_UBLOX_GNSS::begin(Stream &serialPort)
   createFileBuffer();
 
   // Call isConnected up to three times - tests on the NEO-M8U show the CFG RATE poll occasionally being ignored
-  bool connected = isConnected();
+  bool connected = isConnected(maxWait);
 
   if (!connected)
-    connected = isConnected();
+    connected = isConnected(maxWait);
 
   if (!connected)
-    connected = isConnected();
+    connected = isConnected(maxWait);
 
   return (connected);
 }
 
 // Initialize for SPI
-bool SFE_UBLOX_GNSS::begin(SPIClass &spiPort, uint8_t csPin, uint32_t spiSpeed)
+bool SFE_UBLOX_GNSS::begin(SPIClass &spiPort, uint8_t csPin, uint32_t spiSpeed, uint16_t maxWait)
 {
   commType = COMM_TYPE_SPI;
   _spiPort = &spiPort;
@@ -507,13 +507,13 @@ bool SFE_UBLOX_GNSS::begin(SPIClass &spiPort, uint8_t csPin, uint32_t spiSpeed)
   }
 
   // Call isConnected up to three times
-  bool connected = isConnected();
+  bool connected = isConnected(maxWait);
 
   if (!connected)
-    connected = isConnected();
+    connected = isConnected(maxWait);
 
   if (!connected)
-    connected = isConnected();
+    connected = isConnected(maxWait);
 
   return (connected);
 }

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -576,11 +576,11 @@ public:
 	void setPacketCfgPayloadSize(size_t payloadSize); // Set packetCfgPayloadSize
 
 	//By default use the default I2C address, and use Wire port
-	bool begin(TwoWire &wirePort = Wire, uint8_t deviceAddress = 0x42, uint16_t maxWait); //Returns true if module is detected
+	bool begin(TwoWire &wirePort = Wire, uint8_t deviceAddress = 0x42, uint16_t maxWait = 1100); //Returns true if module is detected
 	//serialPort needs to be perviously initialized to correct baud rate
-	bool begin(Stream &serialPort, uint16_t maxWait); //Returns true if module is detected
+	bool begin(Stream &serialPort, uint16_t maxWait = 1100); //Returns true if module is detected
 	//SPI - supply instance of SPIClass, chip select pin and SPI speed (in Hz)
-	bool begin(SPIClass &spiPort, uint8_t csPin, uint32_t spiSpeed, uint16_t maxWait);
+	bool begin(SPIClass &spiPort, uint8_t csPin, uint32_t spiSpeed, uint16_t maxWait = 1100);
 
 	void end(void); //Stop all automatic message processing. Free all used RAM
 

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -576,11 +576,11 @@ public:
 	void setPacketCfgPayloadSize(size_t payloadSize); // Set packetCfgPayloadSize
 
 	//By default use the default I2C address, and use Wire port
-	bool begin(TwoWire &wirePort = Wire, uint8_t deviceAddress = 0x42); //Returns true if module is detected
+	bool begin(TwoWire &wirePort = Wire, uint8_t deviceAddress = 0x42, uint16_t maxWait); //Returns true if module is detected
 	//serialPort needs to be perviously initialized to correct baud rate
-	bool begin(Stream &serialPort); //Returns true if module is detected
+	bool begin(Stream &serialPort, uint16_t maxWait); //Returns true if module is detected
 	//SPI - supply instance of SPIClass, chip select pin and SPI speed (in Hz)
-	bool begin(SPIClass &spiPort, uint8_t csPin, uint32_t spiSpeed);
+	bool begin(SPIClass &spiPort, uint8_t csPin, uint32_t spiSpeed, uint16_t maxWait);
 
 	void end(void); //Stop all automatic message processing. Free all used RAM
 


### PR DESCRIPTION
Passes maxWait into begin function. This is helpful for systems that fail to respond. The default 1100ms really equals 3.3s when isConnected fails multiple times. This allows user to override as needed.