### PR TITLE
Release candidate

### DIFF
--- a/examples/ZED-F9P/Example19_LBand_Corrections_with_NEO-D9S/Example19_LBand_Corrections_with_NEO-D9S.ino
+++ b/examples/ZED-F9P/Example19_LBand_Corrections_with_NEO-D9S/Example19_LBand_Corrections_with_NEO-D9S.ino
@@ -146,7 +146,9 @@ void setup()
   if (ok) ok = myGNSS.setDGNSSConfiguration(SFE_UBLOX_DGNSS_MODE_FIXED); // Set the differential mode - ambiguities are fixed whenever possible
 
   if (ok) ok = myGNSS.setNavigationFrequency(1); //Set output in Hz.
-
+  
+  if (ok) ok = myGNSS.setVal8(UBLOX_CFG_SPARTN_USE_SOURCE, 1); // use LBAND PMP message
+  
   //Configure the SPARTN IP Dynamic Keys
   //"When the receiver boots, the host should send 'current' and 'next' keys in one message." - Use setDynamicSPARTNKeys for this.
   //"Every time the 'current' key is expired, 'next' takes its place."

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -1527,6 +1527,8 @@ uint16_t SFE_UBLOX_GNSS::getMaxPayloadSize(uint8_t Class, uint8_t ID)
 // Take a given byte and file it into the proper array
 void SFE_UBLOX_GNSS::process(uint8_t incoming, ubxPacket *incomingUBX, uint8_t requestedClass, uint8_t requestedID)
 {
+  if (_outputPort != NULL)
+    _outputPort->write(incoming); // Echo this byte to the serial port
   if ((currentSentence == NONE) || (currentSentence == NMEA))
   {
     if (incoming == UBX_SYNCH_1) // UBX binary frames start with 0xB5, aka μ
@@ -6447,6 +6449,11 @@ bool SFE_UBLOX_GNSS::setSPIOutput(uint8_t comSettings, uint16_t maxWait)
 void SFE_UBLOX_GNSS::setNMEAOutputPort(Stream &nmeaOutputPort)
 {
   _nmeaOutputPort = &nmeaOutputPort; // Store the port from user
+}
+
+void SFE_UBLOX_GNSS::setOutputPort(Stream &outputPort)
+{
+  _outputPort = &outputPort; // Store the port from user
 }
 
 // Reset to defaults

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -3312,6 +3312,8 @@ void SFE_UBLOX_GNSS::processUBXpacket(ubxPacket *msg)
 
         packetUBXRXMPMPmessage->callbackData->checksumA = msg->checksumA;
         packetUBXRXMPMPmessage->callbackData->checksumB = msg->checksumB;
+        
+        packetUBXRXMPMPmessage->automaticFlags.flags.bits.callbackCopyValid = true; // Mark the data as valid
       }
     }
     else if (msg->id == UBX_RXM_SFRBX)

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -809,6 +809,7 @@ public:
   bool setUSBOutput(uint8_t comSettings, uint16_t maxWait = defaultMaxWait);   // Configure USB port to output UBX, NMEA, RTCM3, SPARTN or a combination thereof
   bool setSPIOutput(uint8_t comSettings, uint16_t maxWait = defaultMaxWait);   // Configure SPI port to output UBX, NMEA, RTCM3, SPARTN or a combination thereof
   void setNMEAOutputPort(Stream &nmeaOutputPort);                              // Sets the internal variable for the port to direct NMEA characters to
+  void setOutputPort(Stream &outputPort);                                      // Sets the internal variable for the port to direct ALL characters to
 
   // Reset to defaults
 
@@ -1562,7 +1563,7 @@ private:
   Stream *_serialPort;            // The generic connection to user's chosen Serial hardware
   Stream *_nmeaOutputPort = NULL; // The user can assign an output port to print NMEA sentences if they wish
   Stream *_debugSerial;           // The stream to send debug messages to if enabled
-
+  Stream *_outputPort = NULL;
   SPIClass *_spiPort; // The instance of SPIClass
   uint8_t _csPin;     // The chip select pin
   uint32_t _spiSpeed; // The speed to use for SPI (Hz)


### PR DESCRIPTION
Few imporvements: 
- New Feature: outputPort allow logging of any incoming data (e.g to a SDCard File) 
- BugFix: set the UBLOX_CFG_SPARTN_USE_SOURCE to LBAND (= PMP message) in the example
- BugFix: make PMP message as valid so that later the callback is triggered.

Potential Issue: The PMP current approach could trigger an issue if PMP messages arrive faster than the callbacks are triggered. In such a case the captured data is overridden by the next message before it is forwarded to the ZED. This is rather unlikely as PMP arrive slower than every second. 

The failure I saw in GNSS configuration with keys I saw was caused by the "......" in the second key. Maybe we can make it clear with a better message if that fails that customers have to touch the secrets file. or Secrets file could fail compiling. 