### PR TITLE
Long Duration Survey-In Greater Than 65535-seconds

### DIFF
--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -6660,7 +6660,7 @@ bool SFE_UBLOX_GNSS::getSurveyMode(uint16_t maxWait)
 }
 
 // Control Survey-In for NEO-M8P
-bool SFE_UBLOX_GNSS::setSurveyMode(uint8_t mode, uint16_t observationTime, float requiredAccuracy, uint16_t maxWait)
+bool SFE_UBLOX_GNSS::setSurveyMode(uint8_t mode, uint32_t observationTime, float requiredAccuracy, uint16_t maxWait)
 {
   if (getSurveyMode(maxWait) == false) // Ask module for the current TimeMode3 settings. Loads into payloadCfg.
     return (false);
@@ -6673,11 +6673,11 @@ bool SFE_UBLOX_GNSS::setSurveyMode(uint8_t mode, uint16_t observationTime, float
   // payloadCfg should be loaded with poll response. Now modify only the bits we care about
   payloadCfg[2] = mode; // Set mode. Survey-In and Disabled are most common. Use ECEF (not LAT/LON/ALT).
 
-  // svinMinDur is U4 (uint32_t) but we'll only use a uint16_t (waiting more than 65535 seconds seems excessive!)
+  // svinMinDur is U4 (uint32_t) in seconds
   payloadCfg[24] = observationTime & 0xFF; // svinMinDur in seconds
   payloadCfg[25] = observationTime >> 8;   // svinMinDur in seconds
-  payloadCfg[26] = 0;                      // Truncate to 16 bits
-  payloadCfg[27] = 0;                      // Truncate to 16 bits
+  payloadCfg[26] = observationTime >> 16; 
+  payloadCfg[27] = observationTime >> 24; 
 
   // svinAccLimit is U4 (uint32_t) in 0.1mm.
   uint32_t svinAccLimit = (uint32_t)(requiredAccuracy * 10000.0); // Convert m to 0.1mm
@@ -6690,7 +6690,7 @@ bool SFE_UBLOX_GNSS::setSurveyMode(uint8_t mode, uint16_t observationTime, float
 }
 
 // Begin Survey-In for NEO-M8P
-bool SFE_UBLOX_GNSS::enableSurveyMode(uint16_t observationTime, float requiredAccuracy, uint16_t maxWait)
+bool SFE_UBLOX_GNSS::enableSurveyMode(uint32_t observationTime, float requiredAccuracy, uint16_t maxWait)
 {
   return (setSurveyMode(SVIN_MODE_ENABLE, observationTime, requiredAccuracy, maxWait));
 }

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -835,8 +835,8 @@ public:
   // Functions used for RTK and base station setup
   // It is probably safe to assume that users of the RTK will be using I2C / Qwiic. So let's leave maxWait set to 250ms.
   bool getSurveyMode(uint16_t maxWait = 250);                                                                 // Get the current TimeMode3 settings
-  bool setSurveyMode(uint8_t mode, uint16_t observationTime, float requiredAccuracy, uint16_t maxWait = 250); // Control survey in mode
-  bool enableSurveyMode(uint16_t observationTime, float requiredAccuracy, uint16_t maxWait = 250);            // Begin Survey-In for NEO-M8P
+  bool setSurveyMode(uint8_t mode, uint32_t observationTime, float requiredAccuracy, uint16_t maxWait = 250); // Control survey in mode
+  bool enableSurveyMode(uint32_t observationTime, float requiredAccuracy, uint16_t maxWait = 250);            // Begin Survey-In for NEO-M8P
   bool disableSurveyMode(uint16_t maxWait = 250);                                                             // Stop Survey-In mode
   // Given coordinates, put receiver into static position. Set latlong to true to pass in lat/long values instead of ecef.
   // For ECEF the units are: cm, 0.1mm, cm, 0.1mm, cm, 0.1mm


### PR DESCRIPTION
The following changes allow for the library to perform a survey-in longer that 65535-seconds.  Currently the observation time is uint16_t allowing for 65535-seconds.  I wish to perform survey at 86400-seconds (24-hours).  This requires a uint32_t to store the value.