### PR TITLE
Add get/setNAV5PositionAccuracy

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -195,6 +195,10 @@ powerOffWithInterrupt	KEYWORD2
 setDynamicModel	KEYWORD2
 getDynamicModel	KEYWORD2
 
+setNAV5PositionAccuracy	KEYWORD2
+getNAV5PositionAccuracy	KEYWORD2
+
+
 resetOdometer	KEYWORD2
 enableOdometer	KEYWORD2
 getOdometerConfig	KEYWORD2

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -8202,7 +8202,7 @@ bool SFE_UBLOX_GNSS::setupPowerMode(sfe_ublox_rxm_mode_e mode, uint16_t maxWait)
 
 // Change the Position Accuracy using UBX-CFG-NAV5
 // Value provided in meters
-bool SFE_UBLOX_GNSS::setNAV5PositionAccuracy(uint16_t meters, uint16_t maxWait)
+bool SFE_UBLOX_GNSS::setNAV5PositionAccuracy(uint16_t metres, uint16_t maxWait)
 {
   packetCfg.cls = UBX_CLASS_CFG;
   packetCfg.id = UBX_CFG_NAV5;
@@ -8213,9 +8213,9 @@ bool SFE_UBLOX_GNSS::setNAV5PositionAccuracy(uint16_t meters, uint16_t maxWait)
   if (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_DATA_RECEIVED) // We are expecting data and an ACK
     return (false);
 
-  payloadCfg[0] = 0x10;            // mask: set only the posMark
-  payloadCfg[1] = 0x00;            // mask
-  payloadCfg[18] = meters; 
+  payloadCfg[0] |= 0x10; // mask: set the posMark, leave other bits unchanged
+  payloadCfg[18] = metres & 0xFF;
+  payloadCfg[19] = metres >> 8;
 
   packetCfg.len = 36;
   packetCfg.startingSpot = 0;

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -8213,7 +8213,7 @@ bool SFE_UBLOX_GNSS::setNAV5PositionAccuracy(uint16_t metres, uint16_t maxWait)
   if (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_DATA_RECEIVED) // We are expecting data and an ACK
     return (false);
 
-  payloadCfg[0] |= 0x10; // mask: set the posMark, leave other bits unchanged
+  payloadCfg[0] |= 0x10; // mask: set the posMask, leave other bits unchanged
   payloadCfg[18] = metres & 0xFF;
   payloadCfg[19] = metres >> 8;
 

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -8236,7 +8236,10 @@ uint16_t SFE_UBLOX_GNSS::getNAV5PositionAccuracy(uint16_t maxWait)
   if (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_DATA_RECEIVED) // We are expecting data and an ACK
     return 0;
 
-  return (payloadCfg[18]);
+
+  uint16_t pAcc = ((uint16_t)payloadCfg[19]) << 8;
+  pAcc |= payloadCfg[18];
+  return (pAcc);
 }
 
 

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -8197,6 +8197,50 @@ bool SFE_UBLOX_GNSS::setupPowerMode(sfe_ublox_rxm_mode_e mode, uint16_t maxWait)
   return sendCommand(&packetCfg, maxWait);
 }
 
+
+// Position Accuracy
+
+// Change the Position Accuracy using UBX-CFG-NAV5
+// Value provided in meters
+bool SFE_UBLOX_GNSS::setNAV5PositionAccuracy(uint16_t meters, uint16_t maxWait)
+{
+  packetCfg.cls = UBX_CLASS_CFG;
+  packetCfg.id = UBX_CFG_NAV5;
+  packetCfg.len = 0;
+  packetCfg.startingSpot = 0;
+
+  // Ask module for the current navigation model settings. Loads into payloadCfg.
+  if (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_DATA_RECEIVED) // We are expecting data and an ACK
+    return (false);
+
+  payloadCfg[0] = 0x10;            // mask: set only the posMark
+  payloadCfg[1] = 0x00;            // mask
+  payloadCfg[18] = meters; 
+
+  packetCfg.len = 36;
+  packetCfg.startingSpot = 0;
+
+  return (sendCommand(&packetCfg, maxWait) == SFE_UBLOX_STATUS_DATA_SENT); // We are only expecting an ACK
+}
+
+// Get the position accuracy using UBX-CFG-NAV5
+// Returns meters. 0 if the sendCommand fails
+uint16_t SFE_UBLOX_GNSS::getNAV5PositionAccuracy(uint16_t maxWait)
+{
+  packetCfg.cls = UBX_CLASS_CFG;
+  packetCfg.id = UBX_CFG_NAV5;
+  packetCfg.len = 0;
+  packetCfg.startingSpot = 0;
+
+  // Ask module for the current navigation model settings. Loads into payloadCfg.
+  if (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_DATA_RECEIVED) // We are expecting data and an ACK
+    return 0;
+
+  return (payloadCfg[18]);
+}
+
+
+
 // Dynamic Platform Model
 
 // Change the dynamic platform model using UBX-CFG-NAV5

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.cpp
@@ -8263,8 +8263,7 @@ bool SFE_UBLOX_GNSS::setDynamicModel(dynModel newDynamicModel, uint16_t maxWait)
   if (sendCommand(&packetCfg, maxWait) != SFE_UBLOX_STATUS_DATA_RECEIVED) // We are expecting data and an ACK
     return (false);
 
-  payloadCfg[0] = 0x01;            // mask: set only the dyn bit (0)
-  payloadCfg[1] = 0x00;            // mask
+  payloadCfg[0] |= 0x01;            // mask: set only the dyn bit (0)
   payloadCfg[2] = newDynamicModel; // dynModel
 
   packetCfg.len = 36;

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -951,7 +951,7 @@ public:
   uint8_t getDynamicModel(uint16_t maxWait = defaultMaxWait); // Get the dynamic model - returns 255 if the sendCommand fails
 
   // Change the position accuracy using UBX-CFG-NAV5
-  bool setNAV5PositionAccuracy(uint16_t meters = 100, uint16_t maxWait = defaultMaxWait);
+  bool setNAV5PositionAccuracy(uint16_t metres = 100, uint16_t maxWait = defaultMaxWait);
   uint16_t getNAV5PositionAccuracy(uint16_t maxWait = defaultMaxWait); // Get the position accuracy - returns 0 if the sendCommand fails
 
 

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -951,7 +951,7 @@ public:
   uint8_t getDynamicModel(uint16_t maxWait = defaultMaxWait); // Get the dynamic model - returns 255 if the sendCommand fails
 
   // Change the position accuracy using UBX-CFG-NAV5
-  bool setNAV5PositionAccuracy(uint16_t metres = 100, uint16_t maxWait = defaultMaxWait);
+  bool setNAV5PositionAccuracy(uint16_t metres, uint16_t maxWait = defaultMaxWait);
   uint16_t getNAV5PositionAccuracy(uint16_t maxWait = defaultMaxWait); // Get the position accuracy - returns 0 if the sendCommand fails
 
 

--- a/src/SparkFun_u-blox_GNSS_Arduino_Library.h
+++ b/src/SparkFun_u-blox_GNSS_Arduino_Library.h
@@ -950,6 +950,11 @@ public:
   bool setDynamicModel(dynModel newDynamicModel = DYN_MODEL_PORTABLE, uint16_t maxWait = defaultMaxWait);
   uint8_t getDynamicModel(uint16_t maxWait = defaultMaxWait); // Get the dynamic model - returns 255 if the sendCommand fails
 
+  // Change the position accuracy using UBX-CFG-NAV5
+  bool setNAV5PositionAccuracy(uint16_t meters = 100, uint16_t maxWait = defaultMaxWait);
+  uint16_t getNAV5PositionAccuracy(uint16_t maxWait = defaultMaxWait); // Get the position accuracy - returns 0 if the sendCommand fails
+
+
   // Reset / enable / configure the odometer
   bool resetOdometer(uint16_t maxWait = defaultMaxWait); // Reset the odometer
   bool enableOdometer(bool enable = true, uint16_t maxWait = defaultMaxWait); // Enable / disable the odometer


### PR DESCRIPTION
As asked/suggested/requested in #223.

This adds the option so set the pAcc parameter via UBX-CFG-NAV5. 

The name of the method is somewhat strange. this is primarily because there is already a `getPositionAccuracy`. 

