### PR TITLE
CMake requires arduino-esp32 to be compatible with idf component registry

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,5 @@ file(GLOB SOURCES src/*.cpp)
 idf_component_register(
     SRCS ${SOURCES}
     INCLUDE_DIRS src
-    REQUIRES arduino
+    REQUIRES arduino-esp32
 )


### PR DESCRIPTION
Sorry for bothering you again with this, but I found people use `idf.py add-dependency "espressif/arduino-esp32"` instead of clonning arduino manually, which I was doing previously.

The compatibility fix for those people is easy: create `components/arduino` dir that points to `managed_components/espressif__arduino-esp32` but I've decided to push a fix to your lib. I also noted that Adafruit uses `arduino-esp32` and not `arduino`.

So in short, both ways (cloning arduino repo and using idf registry) are valid and described in the official docs. Feel free to close this if you think it does not make a difference.